### PR TITLE
Fix for channels with 0 messages

### DIFF
--- a/main.py
+++ b/main.py
@@ -137,12 +137,19 @@ for element in df.Name:
                 buttons[-2].click()
             elif buttons[-1].text == 'REPORT':
                 buttons[-1].click()
+                
+            back_button = driver.find_element(By.CLASS_NAME, "sidebar-close-button")
+            back_button.click()
 
             a = 0
             print("  Blocked Successfully")
             break
         except BaseException as err:
             #print(str(err))
+            if a == 2: 
+                print("  Can't handle this channel")
+                back_button = driver.find_element(By.CLASS_NAME, "sidebar-close-button")
+                back_button.click()
             a += 1
             time.sleep(1)
 


### PR DESCRIPTION
Previously there was no way for the program to go back to the searching sequence after 3 unsuccessful attempts to report a channel with 0 messages, fixed it by adding the press of the back arrow to error handling. Also contains the previous fix of not going back to the search sequence in the general case